### PR TITLE
Replace use of 'shared_ptr' with 'unique_ptr'

### DIFF
--- a/Source/ConvertSketch.cpp
+++ b/Source/ConvertSketch.cpp
@@ -15,7 +15,7 @@
 
 //One person asked, "Why don't you use Tiled Map Editor?"
 //My answer is, "Why should I work hard, when I don't have to work hard?"
-void convert_sketch(const unsigned char i_current_level, unsigned short& i_level_finish, std::vector<std::shared_ptr<Enemy>>& i_enemies, sf::Color& i_background_color, MapManager& i_map_manager, Mario& i_mario)
+void convert_sketch(const unsigned char i_current_level, unsigned short& i_level_finish, std::vector<std::unique_ptr<Enemy>>& i_enemies, sf::Color& i_background_color, MapManager& i_map_manager, Mario& i_mario)
 {
 	unsigned short map_height;
 
@@ -74,11 +74,11 @@ void convert_sketch(const unsigned char i_current_level, unsigned short& i_level
 				}
 				else if (sf::Color(182, 73, 0) == pixel)
 				{
-					i_enemies.push_back(std::make_shared<Goomba>(sf::Color(0, 0, 85) == i_background_color, CELL_SIZE * a, CELL_SIZE * (b - map_height)));
+					i_enemies.push_back(std::make_unique<Goomba>(sf::Color(0, 0, 85) == i_background_color, CELL_SIZE * a, CELL_SIZE * (b - map_height)));
 				}
 				else if (sf::Color(0, 219, 0) == pixel)
 				{
-					i_enemies.push_back(std::make_shared<Koopa>(sf::Color(0, 0, 85) == i_background_color, CELL_SIZE * a, CELL_SIZE * (b - map_height)));
+					i_enemies.push_back(std::make_unique<Koopa>(sf::Color(0, 0, 85) == i_background_color, CELL_SIZE * a, CELL_SIZE * (b - map_height)));
 				}
 			}
 		}

--- a/Source/Goomba.cpp
+++ b/Source/Goomba.cpp
@@ -107,7 +107,7 @@ void Goomba::draw(const unsigned i_view_x, sf::RenderWindow& i_window)
 	}
 }
 
-void Goomba::update(const unsigned i_view_x, const std::vector<std::shared_ptr<Enemy>>& i_enemies, const MapManager& i_map_manager, Mario& i_mario)
+void Goomba::update(const unsigned i_view_x, const std::vector<std::unique_ptr<Enemy>>& i_enemies, const MapManager& i_map_manager, Mario& i_mario)
 {
 	//I've already explained most of the code here in the Mario class.
 	//I know it's bad to write the same code multiple times.
@@ -153,7 +153,7 @@ void Goomba::update(const unsigned i_view_x, const std::vector<std::shared_ptr<E
 				{
 					for (unsigned short a = 0; a < i_enemies.size(); a++)
 					{
-						if (shared_from_this() != i_enemies[a] && 0 == i_enemies[a]->get_dead(0) && 1 == hit_box.intersects(i_enemies[a]->get_hit_box()))
+						if (this != i_enemies[a].get() && 0 == i_enemies[a]->get_dead(0) && 1 == hit_box.intersects(i_enemies[a]->get_hit_box()))
 						{
 							changed = 1;
 
@@ -209,7 +209,7 @@ void Goomba::update(const unsigned i_view_x, const std::vector<std::shared_ptr<E
 					//Changing direction when colliding with another enemy.
 					for (unsigned short a = 0; a < i_enemies.size(); a++)
 					{
-						if (shared_from_this() != i_enemies[a] && 0 == i_enemies[a]->get_dead(0) && 1 == hit_box.intersects(i_enemies[a]->get_hit_box()))
+						if (this != i_enemies[a].get() && 0 == i_enemies[a]->get_dead(0) && 1 == hit_box.intersects(i_enemies[a]->get_hit_box()))
 						{
 							changed = 1;
 

--- a/Source/Headers/ConvertSketch.hpp
+++ b/Source/Headers/ConvertSketch.hpp
@@ -1,3 +1,3 @@
 #pragma once
 
-void convert_sketch(const unsigned char i_current_level, unsigned short& i_level_finish, std::vector<std::shared_ptr<Enemy>>& i_enemies, sf::Color& i_background_color, MapManager& i_map_manager, Mario& i_mario);
+void convert_sketch(const unsigned char i_current_level, unsigned short& i_level_finish, std::vector<std::unique_ptr<Enemy>>& i_enemies, sf::Color& i_background_color, MapManager& i_map_manager, Mario& i_mario);

--- a/Source/Headers/Enemy.hpp
+++ b/Source/Headers/Enemy.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
-//I used the keyword "this", which returns the memory address of the object. But since I switched to smart pointers, this class must inherit std::enable_shared_from_this<Enemy>. C++ is weird.
 #include "MapManager.hpp"
 
 #include "Mario.hpp"
 #include <SFML/Graphics/Rect.hpp>
 #include <SFML/Graphics/RenderWindow.hpp>
 #include <memory>
-class Enemy : public std::enable_shared_from_this<Enemy>
+class Enemy
 {
 protected:
 	bool dead;
@@ -18,13 +17,14 @@ protected:
 	float y;
 public:
 	Enemy(const float i_x, const float i_y);
+	virtual ~Enemy()  = default;
 
 	virtual bool get_dead(const bool i_deletion) const;
 
 	virtual void die(const unsigned char i_death_type);
 	//Apparently, we can set the function declaration to 0 and that's called a pure virtual function. Again, C++ is weird.
 	virtual void draw(const unsigned i_view_x, sf::RenderWindow& i_window) = 0;
-	virtual void update(const unsigned i_view_x, const std::vector<std::shared_ptr<Enemy>>& i_enemies, const MapManager& i_map_manager, Mario& i_mario) = 0;
+	virtual void update(const unsigned i_view_x, const std::vector<std::unique_ptr<Enemy>>& i_enemies, const MapManager& i_map_manager, Mario& i_mario) = 0;
 
 	sf::FloatRect get_hit_box() const;
 };

--- a/Source/Headers/Goomba.hpp
+++ b/Source/Headers/Goomba.hpp
@@ -29,5 +29,5 @@ public:
 
 	void die(const unsigned char i_death_type);
 	void draw(const unsigned i_view_x, sf::RenderWindow& i_window);
-	void update(const unsigned i_view_x, const std::vector<std::shared_ptr<Enemy>>& i_enemies, const MapManager& i_map_manager, Mario& i_mario);
+	void update(const unsigned i_view_x, const std::vector<std::unique_ptr<Enemy>>& i_enemies, const MapManager& i_map_manager, Mario& i_mario);
 };

--- a/Source/Headers/Koopa.hpp
+++ b/Source/Headers/Koopa.hpp
@@ -33,5 +33,5 @@ public:
 
 	void die(const unsigned char i_death_type);
 	void draw(const unsigned i_view_x, sf::RenderWindow& i_window);
-	void update(const unsigned i_view_x, const std::vector<std::shared_ptr<Enemy>>& i_enemies, const MapManager& i_map_manager, Mario& i_mario);
+	void update(const unsigned i_view_x, const std::vector<std::unique_ptr<Enemy>>& i_enemies, const MapManager& i_map_manager, Mario& i_mario);
 };

--- a/Source/Koopa.cpp
+++ b/Source/Koopa.cpp
@@ -107,7 +107,7 @@ void Koopa::draw(const unsigned i_view_x, sf::RenderWindow& i_window)
 	}
 }
 
-void Koopa::update(const unsigned i_view_x, const std::vector<std::shared_ptr<Enemy>>& i_enemies, const MapManager& i_map_manager, Mario& i_mario)
+void Koopa::update(const unsigned i_view_x, const std::vector<std::unique_ptr<Enemy>>& i_enemies, const MapManager& i_map_manager, Mario& i_mario)
 {
 	//I've already explained most of the code here in the Mario and Goomba classes.
 	//I'm so bad at writing comments lol.
@@ -148,7 +148,7 @@ void Koopa::update(const unsigned i_view_x, const std::vector<std::shared_ptr<En
 
 				for (unsigned short a = 0; a < i_enemies.size(); a++)
 				{
-					if (shared_from_this() != i_enemies[a] && 0 == i_enemies[a]->get_dead(0) && 1 == hit_box.intersects(i_enemies[a]->get_hit_box()))
+					if (this != i_enemies[a].get() && 0 == i_enemies[a]->get_dead(0) && 1 == hit_box.intersects(i_enemies[a]->get_hit_box()))
 					{
 						changed = 1;
 
@@ -200,7 +200,7 @@ void Koopa::update(const unsigned i_view_x, const std::vector<std::shared_ptr<En
 
 				for (unsigned short a = 0; a < i_enemies.size(); a++)
 				{
-					if (shared_from_this() != i_enemies[a] && 0 == i_enemies[a]->get_dead(0) && 1 == hit_box.intersects(i_enemies[a]->get_hit_box()))
+					if (this != i_enemies[a].get() && 0 == i_enemies[a]->get_dead(0) && 1 == hit_box.intersects(i_enemies[a]->get_hit_box()))
 					{
 						if (0 == state)
 						{

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -1,6 +1,7 @@
 #include <array>
 #include <chrono>
 #include <cmath>
+#include <memory>
 #include <SFML/Graphics.hpp>
 
 #include "Headers/Animation.hpp"
@@ -26,7 +27,7 @@ int main()
 
 	//Using smart pointer because I'm smart.
 	//(Because we need to store both Goomba and Koopa objects in the same vector).
-	std::vector<std::shared_ptr<Enemy>> enemies;
+	std::vector<std::unique_ptr<Enemy>> enemies;
 
 	sf::Color background_color = sf::Color(0, 219, 255);
 


### PR DESCRIPTION
Using `shared_ptr` is not necessary in this situation. There's a single ownership of the dynamically allocated enemies and the lifetime is simple and straightforward. For such purposes, `unique_ptr` fits the bill perfectly and `shared_ptr` is overkill.

`shared_ptr` should only be considered for cases where it is logically undecidable who is the last owner of the held resource. This can happen, for instance, in multi-threaded code.